### PR TITLE
encoding: Add annotations to package, remove from module

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,12 @@ The optimized Rego AST format discards generated bodies entirely, and the same r
 Note that this applies equally to empty `else` bodies, which are represented the same way in the original AST, and
 omitted entirely in the optimized format.
 
+### Removed `annotations` attribute from module
+
+OPA already attaches `annotations` to rules. With the Roast format attaching `package` and `subpackages` scoped
+`annotations` to the `package` as well, there is no need to store `annotations` at the module level. Having this
+removed can save a considerable amount of space in well-documented policies, as they should be!
+
 ### Removed `index` attribute from body expressions
 
 In the original AST, each expression in a body carries a numeric `index` attribute. While this doesn't take much space,

--- a/internal/encoding/module.go
+++ b/internal/encoding/module.go
@@ -21,8 +21,14 @@ func (*moduleCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 
 	if mod.Package != nil {
 		stream.WriteObjectField("package")
+
+		if len(mod.Annotations) > 0 {
+			stream.Attachment = mod.Annotations
+		}
+
 		stream.WriteVal(mod.Package)
 
+		stream.Attachment = nil
 		hasWritten = true
 	}
 
@@ -40,27 +46,6 @@ func (*moduleCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 			}
 
 			stream.WriteVal(imp)
-		}
-
-		stream.WriteArrayEnd()
-
-		hasWritten = true
-	}
-
-	if len(mod.Annotations) > 0 {
-		if hasWritten {
-			stream.WriteMore()
-		}
-
-		stream.WriteObjectField("annotations")
-		stream.WriteArrayStart()
-
-		for i, ann := range mod.Annotations {
-			if i > 0 {
-				stream.WriteMore()
-			}
-
-			stream.WriteVal(ann)
 		}
 
 		stream.WriteArrayEnd()

--- a/internal/encoding/module_test.go
+++ b/internal/encoding/module_test.go
@@ -1,0 +1,149 @@
+package encoding
+
+import (
+	"testing"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/open-policy-agent/opa/ast"
+)
+
+func TestAnnotationsOnPackage(t *testing.T) {
+	t.Parallel()
+
+	module := ast.Module{
+		Package: &ast.Package{
+			Location: &ast.Location{
+				Row:  3,
+				Col:  1,
+				Text: []byte("foo"),
+			},
+			Path: ast.Ref{
+				ast.DefaultRootDocument,
+				ast.StringTerm("foo"),
+			},
+		},
+		Annotations: []*ast.Annotations{
+			{
+				Location: &ast.Location{
+					Row: 1,
+					Col: 1,
+				},
+				Scope: "package",
+				Title: "foo",
+			},
+		},
+	}
+
+	json := jsoniter.ConfigFastest
+
+	roast, err := json.MarshalIndent(module, "", "  ")
+	if err != nil {
+		t.Fatalf("failed to marshal annotations: %v", err)
+	}
+
+	// package annotations should end up on the package object
+	// and *not* on the module object, contrary to how OPA
+	// currently does it
+
+	expected := `{
+  "package": {
+    "location": "3:1:Zm9v",
+    "path": [
+      {
+        "type": "var",
+        "value": "data"
+      },
+      {
+        "type": "string",
+        "value": "foo"
+      }
+    ],
+    "annotations": [
+      {
+        "location": "1:1:",
+        "scope": "package",
+        "title": "foo"
+      }
+    ]
+  }
+}`
+
+	if string(roast) != expected {
+		t.Fatalf("expected %s but got %s", expected, roast)
+	}
+}
+
+func TestAnnotationsOnPackageBothPackageAndSubpackagesScope(t *testing.T) {
+	t.Parallel()
+
+	module := ast.Module{
+		Package: &ast.Package{
+			Location: &ast.Location{
+				Row:  6,
+				Col:  1,
+				Text: []byte("foo"),
+			},
+			Path: ast.Ref{
+				ast.DefaultRootDocument,
+				ast.StringTerm("foo"),
+			},
+		},
+		Annotations: []*ast.Annotations{
+			{
+				Location: &ast.Location{
+					Row: 1,
+					Col: 1,
+				},
+				Scope: "package",
+				Title: "foo",
+			},
+			{
+				Location: &ast.Location{
+					Row: 3,
+					Col: 1,
+				},
+				Scope: "subpackages",
+				Title: "bar",
+			},
+		},
+	}
+
+	json := jsoniter.ConfigFastest
+
+	roast, err := json.MarshalIndent(module, "", "  ")
+	if err != nil {
+		t.Fatalf("failed to marshal annotations: %v", err)
+	}
+
+	expected := `{
+  "package": {
+    "location": "6:1:Zm9v",
+    "path": [
+      {
+        "type": "var",
+        "value": "data"
+      },
+      {
+        "type": "string",
+        "value": "foo"
+      }
+    ],
+    "annotations": [
+      {
+        "location": "1:1:",
+        "scope": "package",
+        "title": "foo"
+      },
+      {
+        "location": "3:1:",
+        "scope": "subpackages",
+        "title": "bar"
+      }
+    ]
+  }
+}`
+
+	if string(roast) != expected {
+		t.Fatalf("expected %s but got %s", expected, roast)
+	}
+}

--- a/internal/encoding/package.go
+++ b/internal/encoding/package.go
@@ -31,5 +31,11 @@ func (*packageCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 		stream.WriteVal(pkg.Path)
 	}
 
+	if stream.Attachment != nil {
+		stream.WriteMore()
+		stream.WriteObjectField("annotations")
+		stream.WriteVal(stream.Attachment)
+	}
+
 	stream.WriteObjectEnd()
 }


### PR DESCRIPTION
We already have rule annotations on rules, and with package annotations moved to the package itself, we can get rid of the `annotations` on the module entirely.

Fixes #4