### PR TITLE
Remove `name` attribute from rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,14 +179,21 @@ omitted entirely in the optimized format.
 ### Removed `annotations` attribute from module
 
 OPA already attaches `annotations` to rules. With the Roast format attaching `package` and `subpackages` scoped
-`annotations` to the `package` as well, there is no need to store `annotations` at the module level. Having this
-removed can save a considerable amount of space in well-documented policies, as they should be!
+`annotations` to the `package` as well, there is no need to store `annotations` at the module level, as that's
+effectively just duplicating data. Having this removed can save a considerable amount of space in well-documented
+policies, as they should be!
 
 ### Removed `index` attribute from body expressions
 
 In the original AST, each expression in a body carries a numeric `index` attribute. While this doesn't take much space,
 it is largely redundant, as the same number can be inferred from the order of the expressions in the body array. It's
 therefore been removed from the Roast format.
+
+### Removed`name` attribute from rule heads
+
+The `name` attribute found in the OPA AST for `rules` is unreliable, as it's not always present. The `ref`
+attribute however always is.  While this doesn't come with any real cost in terms of AST size or performance, consistency
+is key.
 
 ### Fixed inconsistencies in the original Rego AST
 
@@ -213,10 +220,3 @@ location of any given node. Rather than base64-encoding the the bytes of the tex
 count the number of newlines in the text, and from that plus the number of bytes on the last line (if more than one)
 determine the end location. It would then be assumed that the client has the means to translate that into the
 equivalence of `text` where necessary. Regal could for example easily do this from `input.regal.file.lines`.
-
-### Remove `name` attribute from rule heads
-
-The `name` attribute that "traditional" rules have is just duplicating information from the rule head's
-`ref`. While this doesn't come with any real cost in terms of AST size or performance, we've already had cases in
-Regal where some linters referred to the `name` of a rule, only to find out the hard way that it isn't always there.
-In order to avoid that, we should remove `name` from rule heads, and ensure that `ref` is always present.

--- a/internal/encoding/rule.go
+++ b/internal/encoding/rule.go
@@ -77,17 +77,6 @@ func (*ruleCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 			hasWrittenHead = true
 		}
 
-		if rule.Head.Name != "" {
-			if hasWrittenHead {
-				stream.WriteMore()
-			}
-
-			stream.WriteObjectField("name")
-			stream.WriteVal(rule.Head.Name)
-
-			hasWrittenHead = true
-		}
-
 		if rule.Head.Reference != nil {
 			if hasWrittenHead {
 				stream.WriteMore()


### PR DESCRIPTION
This is effectively deprecated anyway, and consumers should just use the `ref` path.