### PR TITLE
location: replace `text` with end location

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,6 @@ And in the OPA JSON AST format:
 
 Notice how there's 20 lines of JSON just to represent the body, even though there isn't really one!
 
-
 The optimized Rego AST format discards generated bodies entirely, and the same rule would be represented as:
 
 ```json
@@ -175,6 +174,9 @@ The optimized Rego AST format discards generated bodies entirely, and the same r
 
 Note that this applies equally to empty `else` bodies, which are represented the same way in the original AST, and
 omitted entirely in the optimized format.
+
+Similarly, Roast discards `location` attributes from attributes that don't have an actual location in the source code.
+An example of this is the `data` term of a package path, which is present only in the AST.
 
 ### Removed `annotations` attribute from module
 

--- a/internal/encoding/head.go
+++ b/internal/encoding/head.go
@@ -1,0 +1,82 @@
+package encoding
+
+import (
+	jsoniter "github.com/json-iterator/go"
+	"github.com/open-policy-agent/opa/ast"
+	"unsafe"
+)
+
+type headCodec struct{}
+
+func (*headCodec) IsEmpty(_ unsafe.Pointer) bool {
+	return false
+}
+
+func (*headCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
+	head := *((*ast.Head)(ptr))
+
+	stream.WriteObjectStart()
+
+	var hasWritten bool
+	if head.Location != nil {
+		stream.WriteObjectField(strLocation)
+		stream.WriteVal(head.Location)
+
+		hasWritten = true
+	}
+
+	if head.Reference != nil {
+		if hasWritten {
+			stream.WriteMore()
+		}
+
+		stream.WriteObjectField(strRef)
+		stream.WriteVal(head.Reference)
+
+		hasWritten = true
+	}
+
+	if len(head.Args) > 0 {
+		if hasWritten {
+			stream.WriteMore()
+		}
+
+		stream.WriteObjectField(strArgs)
+		writeTermsArray(stream, head.Args)
+
+		hasWritten = true
+	}
+
+	if head.Assign {
+		if hasWritten {
+			stream.WriteMore()
+		}
+
+		stream.WriteObjectField(strAssign)
+		stream.WriteBool(head.Assign)
+
+		hasWritten = true
+	}
+
+	if head.Key != nil {
+		if hasWritten {
+			stream.WriteMore()
+		}
+
+		stream.WriteObjectField(strKey)
+		stream.WriteVal(head.Key)
+
+		hasWritten = true
+	}
+
+	if head.Value != nil {
+		if hasWritten {
+			stream.WriteMore()
+		}
+
+		stream.WriteObjectField(strValue)
+		stream.WriteVal(head.Value)
+	}
+
+	stream.WriteObjectEnd()
+}

--- a/internal/encoding/head_test.go
+++ b/internal/encoding/head_test.go
@@ -1,0 +1,79 @@
+package encoding
+
+import (
+	jsoniter "github.com/json-iterator/go"
+	"github.com/open-policy-agent/opa/ast"
+	"testing"
+)
+
+func TestRuleHeadEncoding(t *testing.T) {
+	t.Parallel()
+
+	head := ast.Head{
+		Name: "omitted",
+		Reference: ast.Ref{
+			{
+				Value: ast.String("foo"),
+				Location: &ast.Location{
+					Row:  1,
+					Col:  1,
+					Text: []byte("foo"),
+				},
+			},
+			{
+				Value: ast.String("bar"),
+				Location: &ast.Location{
+					Row:  1,
+					Col:  5, // following "foo."
+					Text: []byte("bar"),
+				},
+			},
+		},
+
+		Value: &ast.Term{
+			Value: ast.Boolean(true),
+			Location: &ast.Location{
+				Row:  1,
+				Col:  12, // following "foo.bar := "
+				Text: []byte("true"),
+			},
+		},
+		Assign: true,
+		Location: &ast.Location{
+			Row:  1,
+			Col:  1,
+			Text: []byte("foo.bar := true"),
+		},
+	}
+
+	bs, err := jsoniter.ConfigFastest.MarshalIndent(head, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expect := `{
+  "location": "1:1:1:16",
+  "ref": [
+    {
+      "location": "1:1:1:4",
+      "type": "string",
+      "value": "foo"
+    },
+    {
+      "location": "1:5:1:8",
+      "type": "string",
+      "value": "bar"
+    }
+  ],
+  "assign": true,
+  "value": {
+    "location": "1:12:1:16",
+    "type": "boolean",
+    "value": true
+  }
+}`
+
+	if string(bs) != expect {
+		t.Fatalf("expected %s but got %s", expect, string(bs))
+	}
+}

--- a/internal/encoding/init.go
+++ b/internal/encoding/init.go
@@ -8,6 +8,7 @@ func init() {
 	jsoniter.RegisterTypeEncoder("ast.Import", &importCodec{})
 	jsoniter.RegisterTypeEncoder("ast.Annotations", &annotationsCodec{})
 	jsoniter.RegisterTypeEncoder("ast.Rule", &ruleCodec{})
+	jsoniter.RegisterTypeEncoder("ast.Head", &headCodec{})
 	jsoniter.RegisterTypeEncoder("ast.Body", &bodyCodec{})
 	jsoniter.RegisterTypeEncoder("ast.Expr", &exprCodec{})
 	jsoniter.RegisterTypeEncoder("ast.Ref", &refCodec{})

--- a/internal/encoding/location.go
+++ b/internal/encoding/location.go
@@ -1,21 +1,63 @@
 package encoding
 
 import (
-	"encoding/base64"
-	"fmt"
+	"bytes"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/open-policy-agent/opa/ast"
+	"strconv"
+	"strings"
+	"sync"
 	"unsafe"
 )
 
 type locationCodec struct{}
+
+var newLine = []byte("\n")
+
+var sbPool = sync.Pool{
+	New: func() any {
+		return new(strings.Builder)
+	},
+}
 
 func (*locationCodec) IsEmpty(_ unsafe.Pointer) bool {
 	return false
 }
 
 func (*locationCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
-	loc := *((*ast.Location)(ptr))
+	location := *((*ast.Location)(ptr))
 
-	stream.WriteString(fmt.Sprintf("%d:%d:%s", loc.Row, loc.Col, base64.StdEncoding.EncodeToString(loc.Text)))
+	var endRow, endCol int
+	if location.Text == nil {
+		endRow = location.Row
+		endCol = location.Col
+	} else {
+		lines := bytes.Split(location.Text, newLine)
+
+		numLines := len(lines)
+
+		endRow = location.Row + numLines - 1
+
+		if numLines == 1 {
+			endCol = location.Col + len(location.Text)
+		} else {
+			lastLine := lines[numLines-1]
+			endCol = len(lastLine) + 1
+		}
+	}
+
+	sb := sbPool.Get().(*strings.Builder)
+
+	sb.WriteString(strconv.Itoa(location.Row))
+	sb.WriteByte(':')
+	sb.WriteString(strconv.Itoa(location.Col))
+	sb.WriteByte(':')
+	sb.WriteString(strconv.Itoa(endRow))
+	sb.WriteByte(':')
+	sb.WriteString(strconv.Itoa(endCol))
+
+	stream.WriteString(sb.String())
+
+	sb.Reset()
+	sbPool.Put(sb)
 }

--- a/internal/encoding/location_test.go
+++ b/internal/encoding/location_test.go
@@ -1,0 +1,114 @@
+package encoding
+
+import (
+	"fmt"
+	jsoniter "github.com/json-iterator/go"
+	"github.com/open-policy-agent/opa/ast"
+	"testing"
+)
+
+func TestLocation(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		location ast.Location
+		expected string
+	}{
+		{
+			name: "multiple lines",
+			location: ast.Location{
+				Row:  5,
+				Col:  2,
+				Text: []byte("allow if {\n	input.foo == true\n}"),
+			},
+			expected: "5:2:7:2",
+		},
+		{
+			name: "single line",
+			location: ast.Location{
+				Row:  1,
+				Col:  1,
+				Text: []byte("package example"),
+			},
+			expected: "1:1:1:16",
+		},
+	}
+
+	json := jsoniter.ConfigFastest
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			stream := json.BorrowStream(nil)
+			defer json.ReturnStream(stream)
+
+			stream.WriteVal(tc.location)
+
+			if string(stream.Buffer()) != fmt.Sprintf("\"%s\"", tc.expected) {
+				t.Fatalf("expected %s but got %s", tc.expected, string(stream.Buffer()))
+			}
+		})
+	}
+}
+
+func TestLocationHeadValue(t *testing.T) {
+	// Separate test for this as we found the end position would sometimes be off,
+	// e.g. the end column would be presented as before the start column.
+	t.Parallel()
+
+	module := ast.MustParseModule("package foo.bar\n\nrule := true")
+	json := jsoniter.ConfigFastest
+
+	out, err := json.MarshalIndent(module, "", "  ")
+	if err != nil {
+		t.Fatalf("failed to marshal module: %v", err)
+	}
+
+	expect := `{
+  "package": {
+    "location": "1:1:1:8",
+    "path": [
+      {
+        "type": "var",
+        "value": "data"
+      },
+      {
+        "location": "1:9:1:12",
+        "type": "string",
+        "value": "foo"
+      },
+      {
+        "location": "1:13:1:16",
+        "type": "string",
+        "value": "bar"
+      }
+    ]
+  },
+  "rules": [
+    {
+      "location": "3:1:3:13",
+      "head": {
+        "location": "3:1:3:13",
+        "ref": [
+          {
+            "location": "3:1:3:5",
+            "type": "var",
+            "value": "rule"
+          }
+        ],
+        "assign": true,
+        "value": {
+          "location": "3:9:3:13",
+          "type": "boolean",
+          "value": true
+        }
+      }
+    }
+  ]
+}`
+	if string(out) != expect {
+		t.Fatalf("expected %s but got %s", expect, out)
+	}
+}

--- a/internal/encoding/module_test.go
+++ b/internal/encoding/module_test.go
@@ -47,7 +47,7 @@ func TestAnnotationsOnPackage(t *testing.T) {
 
 	expected := `{
   "package": {
-    "location": "3:1:Zm9v",
+    "location": "3:1:3:4",
     "path": [
       {
         "type": "var",
@@ -60,7 +60,7 @@ func TestAnnotationsOnPackage(t *testing.T) {
     ],
     "annotations": [
       {
-        "location": "1:1:",
+        "location": "1:1:1:1",
         "scope": "package",
         "title": "foo"
       }
@@ -117,7 +117,7 @@ func TestAnnotationsOnPackageBothPackageAndSubpackagesScope(t *testing.T) {
 
 	expected := `{
   "package": {
-    "location": "6:1:Zm9v",
+    "location": "6:1:6:4",
     "path": [
       {
         "type": "var",
@@ -130,12 +130,12 @@ func TestAnnotationsOnPackageBothPackageAndSubpackagesScope(t *testing.T) {
     ],
     "annotations": [
       {
-        "location": "1:1:",
+        "location": "1:1:1:1",
         "scope": "package",
         "title": "foo"
       },
       {
-        "location": "3:1:",
+        "location": "3:1:3:1",
         "scope": "subpackages",
         "title": "bar"
       }

--- a/internal/encoding/package.go
+++ b/internal/encoding/package.go
@@ -28,6 +28,10 @@ func (*packageCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 		}
 
 		stream.WriteObjectField(strPath)
+
+		// Omit location of "data" part of path, at it isn't present in code
+		pkg.Path[0].Location = nil
+
 		stream.WriteVal(pkg.Path)
 	}
 

--- a/internal/encoding/rule.go
+++ b/internal/encoding/rule.go
@@ -66,73 +66,7 @@ func (*ruleCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 		}
 
 		stream.WriteObjectField(strHead)
-		stream.WriteObjectStart()
-
-		hasWrittenHead := false
-
-		if rule.Head.Location != nil {
-			stream.WriteObjectField(strLocation)
-			stream.WriteVal(rule.Head.Location)
-
-			hasWrittenHead = true
-		}
-
-		if rule.Head.Reference != nil {
-			if hasWrittenHead {
-				stream.WriteMore()
-			}
-
-			stream.WriteObjectField(strRef)
-			stream.WriteVal(rule.Head.Reference)
-
-			hasWrittenHead = true
-		}
-
-		if len(rule.Head.Args) > 0 {
-			if hasWrittenHead {
-				stream.WriteMore()
-			}
-
-			stream.WriteObjectField(strArgs)
-			writeTermsArray(stream, rule.Head.Args)
-
-			hasWrittenHead = true
-		}
-
-		if rule.Head.Assign {
-			if hasWrittenHead {
-				stream.WriteMore()
-			}
-
-			stream.WriteObjectField(strAssign)
-			stream.WriteBool(rule.Head.Assign)
-
-			hasWrittenHead = true
-		}
-
-		if rule.Head.Key != nil {
-			if hasWrittenHead {
-				stream.WriteMore()
-			}
-
-			stream.WriteObjectField(strKey)
-			stream.WriteVal(rule.Head.Key)
-
-			hasWrittenHead = true
-		}
-
-		if rule.Head.Value != nil {
-			if hasWrittenHead {
-				stream.WriteMore()
-			}
-
-			stream.WriteObjectField(strValue)
-			stream.WriteVal(rule.Head.Value)
-		}
-
-		stream.WriteObjectEnd()
-
-		hasWritten = true
+		stream.WriteVal(rule.Head)
 	}
 
 	if !isBodyGenerated(&rule) {

--- a/internal/encoding/testdata/annotations_all.json
+++ b/internal/encoding/testdata/annotations_all.json
@@ -1,5 +1,5 @@
 {
-  "location": "1:2:",
+  "location": "1:2:1:2",
   "scope": "document",
   "title": "this is a title",
   "description": "this is a description",
@@ -26,19 +26,19 @@
     {
       "path": [
         {
-          "location": "1:1:aW5wdXQ=",
+          "location": "1:1:1:6",
           "type": "var",
           "value": "input"
         }
       ],
       "schema": [
         {
-          "location": "1:1:c2NoZW1h",
+          "location": "1:1:1:7",
           "type": "var",
           "value": "schema"
         },
         {
-          "location": "1:8:aW5wdXQ=",
+          "location": "1:8:1:13",
           "type": "string",
           "value": "input"
         }
@@ -47,34 +47,34 @@
     {
       "path": [
         {
-          "location": "1:1:ZGF0YQ==",
+          "location": "1:1:1:5",
           "type": "var",
           "value": "data"
         },
         {
-          "location": "1:6:Zm9v",
+          "location": "1:6:1:9",
           "type": "string",
           "value": "foo"
         },
         {
-          "location": "1:10:YmFy",
+          "location": "1:10:1:13",
           "type": "string",
           "value": "bar"
         }
       ],
       "schema": [
         {
-          "location": "1:1:c2NoZW1h",
+          "location": "1:1:1:7",
           "type": "var",
           "value": "schema"
         },
         {
-          "location": "1:8:Zm9v",
+          "location": "1:8:1:11",
           "type": "string",
           "value": "foo"
         },
         {
-          "location": "1:12:YmFy",
+          "location": "1:12:1:15",
           "type": "string",
           "value": "bar"
         }
@@ -83,17 +83,17 @@
     {
       "path": [
         {
-          "location": "1:1:ZGF0YQ==",
+          "location": "1:1:1:5",
           "type": "var",
           "value": "data"
         },
         {
-          "location": "1:6:Zm9v",
+          "location": "1:6:1:9",
           "type": "string",
           "value": "foo"
         },
         {
-          "location": "1:10:YmF6",
+          "location": "1:10:1:13",
           "type": "string",
           "value": "baz"
         }


### PR DESCRIPTION
Most importantly, this provides an end location for all nodes, making it much easier (and less expensive) to highlight issues more precisely, from the start location to the end.

Naturally, not having `text` embedded in the AST also reduces its size.

While the performance benefit of this is yet unknown, it does at least save space. The size of the serialized AST for Regal goes from ~12 MB to 10.

Also in this PR:
- Create a separate encoder for `ast.Head`, so that we may marshal (and test) it without having a full `ast.Rule`.