### PR TITLE
Don't serialize rule/document scoped annotations on package node

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -51,7 +51,7 @@ linters-settings:
       - default
       - prefix(github.com/open-policy-agent/opa)
       - prefix(github.com/styrainc/regal)
-      - prefix(github.com/styrainc/roast)
+      - prefix(github.com/anderseknert/roast)
       - blank
       - dot
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.7.0] -
+
+### Changed
+
+- Annotations scoped `rule` or `document` no longer serialized under the `package` node, but found under each
+  respective rule only. Marginal performance improvement, but certainly more correct.
+
 ## [0.6.0] - 2025-01-14
 
 ### Changed

--- a/internal/encoding/annotations.go
+++ b/internal/encoding/annotations.go
@@ -5,6 +5,8 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 
+	"github.com/anderseknert/roast/internal/encoding/util"
+
 	"github.com/open-policy-agent/opa/v1/ast"
 )
 
@@ -49,86 +51,31 @@ func (*annotationsCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	if len(a.Organizations) > 0 {
 		stream.WriteMore()
 		stream.WriteObjectField(strOrganizations)
-		stream.WriteArrayStart()
-
-		for i, org := range a.Organizations {
-			if i > 0 {
-				stream.WriteMore()
-			}
-
-			stream.WriteString(org)
-		}
-
-		stream.WriteArrayEnd()
+		util.WriteStringsArray(stream, a.Organizations)
 	}
 
 	if len(a.RelatedResources) > 0 {
 		stream.WriteMore()
 		stream.WriteObjectField(strRelatedResources)
-		stream.WriteArrayStart()
-
-		for i, res := range a.RelatedResources {
-			if i > 0 {
-				stream.WriteMore()
-			}
-
-			stream.WriteVal(res)
-		}
-
-		stream.WriteArrayEnd()
+		util.WriteValsArray(stream, a.RelatedResources)
 	}
 
 	if len(a.Authors) > 0 {
 		stream.WriteMore()
 		stream.WriteObjectField(strAuthors)
-		stream.WriteArrayStart()
-
-		for i, author := range a.Authors {
-			if i > 0 {
-				stream.WriteMore()
-			}
-
-			stream.WriteVal(author)
-		}
-
-		stream.WriteArrayEnd()
+		util.WriteValsArray(stream, a.Authors)
 	}
 
 	if len(a.Schemas) > 0 {
 		stream.WriteMore()
 		stream.WriteObjectField(strSchemas)
-		stream.WriteArrayStart()
-
-		for i, schema := range a.Schemas {
-			if i > 0 {
-				stream.WriteMore()
-			}
-
-			stream.WriteVal(schema)
-		}
-
-		stream.WriteArrayEnd()
+		util.WriteValsArray(stream, a.Schemas)
 	}
 
 	if len(a.Custom) > 0 {
 		stream.WriteMore()
 		stream.WriteObjectField(strCustom)
-		stream.WriteObjectStart()
-
-		i := 0
-
-		for key, value := range a.Custom {
-			if i > 0 {
-				stream.WriteMore()
-			}
-
-			stream.WriteObjectField(key)
-			stream.WriteVal(value)
-
-			i++
-		}
-
-		stream.WriteObjectEnd()
+		util.WriteObject(stream, a.Custom)
 	}
 
 	stream.WriteObjectEnd()

--- a/internal/encoding/annotations_test.go
+++ b/internal/encoding/annotations_test.go
@@ -135,3 +135,14 @@ func MustReadFile(t *testing.T, path string) []byte {
 
 	return bs
 }
+
+func MustReadFileBench(b *testing.B, path string) []byte {
+	b.Helper()
+
+	bs, err := os.ReadFile(path)
+	if err != nil {
+		b.Fatalf("failed to read file %s: %v", path, err)
+	}
+
+	return bs
+}

--- a/internal/encoding/body.go
+++ b/internal/encoding/body.go
@@ -5,6 +5,8 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 
+	"github.com/anderseknert/roast/internal/encoding/util"
+
 	"github.com/open-policy-agent/opa/v1/ast"
 )
 
@@ -17,15 +19,5 @@ func (*bodyCodec) IsEmpty(_ unsafe.Pointer) bool {
 func (*bodyCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	body := *((*ast.Body)(ptr))
 
-	stream.WriteArrayStart()
-
-	for i, expr := range body {
-		if i > 0 {
-			stream.WriteMore()
-		}
-
-		stream.WriteVal(expr)
-	}
-
-	stream.WriteArrayEnd()
+	util.WriteValsArray(stream, body)
 }

--- a/internal/encoding/expr.go
+++ b/internal/encoding/expr.go
@@ -5,6 +5,8 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 
+	"github.com/anderseknert/roast/internal/encoding/util"
+
 	"github.com/open-policy-agent/opa/v1/ast"
 )
 
@@ -56,17 +58,7 @@ func (*exprCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 		}
 
 		stream.WriteObjectField(strWith)
-		stream.WriteArrayStart()
-
-		for i, with := range expr.With {
-			if i > 0 {
-				stream.WriteMore()
-			}
-
-			stream.WriteVal(with)
-		}
-
-		stream.WriteArrayEnd()
+		util.WriteValsArray(stream, expr.With)
 
 		hasWritten = true
 	}

--- a/internal/encoding/module.go
+++ b/internal/encoding/module.go
@@ -5,6 +5,9 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 
+	encutil "github.com/anderseknert/roast/internal/encoding/util"
+	"github.com/anderseknert/roast/pkg/util"
+
 	"github.com/open-policy-agent/opa/v1/ast"
 )
 
@@ -25,7 +28,7 @@ func (*moduleCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 		stream.WriteObjectField(strPackage)
 
 		if len(mod.Annotations) > 0 {
-			stream.Attachment = mod.Annotations
+			stream.Attachment = util.Filter(mod.Annotations, notDocumentOrRuleScope)
 		}
 
 		stream.WriteVal(mod.Package)
@@ -40,17 +43,7 @@ func (*moduleCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 		}
 
 		stream.WriteObjectField(strImports)
-		stream.WriteArrayStart()
-
-		for i, imp := range mod.Imports {
-			if i > 0 {
-				stream.WriteMore()
-			}
-
-			stream.WriteVal(imp)
-		}
-
-		stream.WriteArrayEnd()
+		encutil.WriteValsArray(stream, mod.Imports)
 
 		hasWritten = true
 	}
@@ -61,17 +54,7 @@ func (*moduleCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 		}
 
 		stream.WriteObjectField(strRules)
-		stream.WriteArrayStart()
-
-		for i, rule := range mod.Rules {
-			if i > 0 {
-				stream.WriteMore()
-			}
-
-			stream.WriteVal(rule)
-		}
-
-		stream.WriteArrayEnd()
+		encutil.WriteValsArray(stream, mod.Rules)
 
 		hasWritten = true
 	}
@@ -82,18 +65,12 @@ func (*moduleCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 		}
 
 		stream.WriteObjectField(strComments)
-		stream.WriteArrayStart()
-
-		for i, comment := range mod.Comments {
-			if i > 0 {
-				stream.WriteMore()
-			}
-
-			stream.WriteVal(comment)
-		}
-
-		stream.WriteArrayEnd()
+		encutil.WriteValsArray(stream, mod.Comments)
 	}
 
 	stream.WriteObjectEnd()
+}
+
+func notDocumentOrRuleScope(a *ast.Annotations) bool {
+	return a.Scope != "document" && a.Scope != "rule"
 }

--- a/internal/encoding/module_test.go
+++ b/internal/encoding/module_test.go
@@ -8,21 +8,23 @@ import (
 	"github.com/open-policy-agent/opa/v1/ast"
 )
 
+var pkg = &ast.Package{
+	Location: &ast.Location{
+		Row:  6,
+		Col:  1,
+		Text: []byte("foo"),
+	},
+	Path: ast.Ref{
+		ast.DefaultRootDocument,
+		ast.StringTerm("foo"),
+	},
+}
+
 func TestAnnotationsOnPackage(t *testing.T) {
 	t.Parallel()
 
 	module := ast.Module{
-		Package: &ast.Package{
-			Location: &ast.Location{
-				Row:  3,
-				Col:  1,
-				Text: []byte("foo"),
-			},
-			Path: ast.Ref{
-				ast.DefaultRootDocument,
-				ast.StringTerm("foo"),
-			},
-		},
+		Package: pkg,
 		Annotations: []*ast.Annotations{
 			{
 				Location: &ast.Location{
@@ -48,7 +50,7 @@ func TestAnnotationsOnPackage(t *testing.T) {
 
 	expected := `{
   "package": {
-    "location": "3:1:3:4",
+    "location": "6:1:6:4",
     "path": [
       {
         "type": "var",
@@ -78,17 +80,7 @@ func TestAnnotationsOnPackageBothPackageAndSubpackagesScope(t *testing.T) {
 	t.Parallel()
 
 	module := ast.Module{
-		Package: &ast.Package{
-			Location: &ast.Location{
-				Row:  6,
-				Col:  1,
-				Text: []byte("foo"),
-			},
-			Path: ast.Ref{
-				ast.DefaultRootDocument,
-				ast.StringTerm("foo"),
-			},
-		},
+		Package: pkg,
 		Annotations: []*ast.Annotations{
 			{
 				Location: &ast.Location{
@@ -146,5 +138,117 @@ func TestAnnotationsOnPackageBothPackageAndSubpackagesScope(t *testing.T) {
 
 	if string(roast) != expected {
 		t.Fatalf("expected %s but got %s", expected, roast)
+	}
+}
+
+func TestRuleAndDocumentScopedAnnotationsOnPackageAreDropped(t *testing.T) {
+	t.Parallel()
+
+	module := ast.Module{
+		Package: pkg,
+		Annotations: []*ast.Annotations{
+			{
+				Location: &ast.Location{
+					Row: 1,
+					Col: 1,
+				},
+				Scope: "package",
+				Title: "foo",
+			},
+			{
+				Location: &ast.Location{
+					Row: 3,
+					Col: 1,
+				},
+				Scope: "rule",
+				Title: "bar",
+			},
+			{
+				Location: &ast.Location{
+					Row: 4,
+					Col: 1,
+				},
+				Scope: "document",
+				Title: "baz",
+			},
+		},
+	}
+
+	json := jsoniter.ConfigFastest
+
+	roast, err := json.MarshalIndent(module, "", "  ")
+	if err != nil {
+		t.Fatalf("failed to marshal annotations: %v", err)
+	}
+
+	expected := `{
+  "package": {
+    "location": "6:1:6:4",
+    "path": [
+      {
+        "type": "var",
+        "value": "data"
+      },
+      {
+        "type": "string",
+        "value": "foo"
+      }
+    ],
+    "annotations": [
+      {
+        "location": "1:1:1:1",
+        "scope": "package",
+        "title": "foo"
+      }
+    ]
+  }
+}`
+
+	if string(roast) != expected {
+		t.Fatalf("expected %s but got %s", expected, roast)
+	}
+}
+
+func TestSerializedModuleSize(t *testing.T) {
+	t.Parallel()
+
+	policy := MustReadFile(t, "testdata/policy.rego")
+	module := ast.MustParseModuleWithOpts(string(policy), ast.ParserOptions{
+		ProcessAnnotation: true,
+	})
+
+	json := jsoniter.ConfigFastest
+
+	roast, err := json.Marshal(module)
+	if err != nil {
+		t.Fatalf("failed to marshal module: %v", err)
+	}
+
+	// This test will fail whenever the size of the serialized module changes,
+	// which not often and when it happens it's good to know about it, update
+	// and move on.
+	if len(roast) != 85979 {
+		t.Fatalf("expected %d but got %d", 85979, len(roast))
+	}
+}
+
+// BenchmarkSerializeModule-10    	    2281	    500175 ns/op	  219349 B/op	    9883 allocs/op
+// BenchmarkSerializeModule-10    	    2488	    479095 ns/op	  217090 B/op	    9805 allocs/op
+
+func BenchmarkSerializeModule(b *testing.B) {
+	policy := MustReadFileBench(b, "testdata/policy.rego")
+	module := ast.MustParseModuleWithOpts(string(policy), ast.ParserOptions{
+		ProcessAnnotation: true,
+	})
+
+	json := jsoniter.ConfigFastest
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := json.Marshal(module)
+		if err != nil {
+			b.Fatalf("failed to marshal module: %v", err)
+		}
 	}
 }

--- a/internal/encoding/rule.go
+++ b/internal/encoding/rule.go
@@ -5,6 +5,8 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 
+	"github.com/anderseknert/roast/internal/encoding/util"
+
 	"github.com/open-policy-agent/opa/v1/ast"
 )
 
@@ -34,17 +36,7 @@ func (*ruleCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 		}
 
 		stream.WriteObjectField(strAnnotations)
-		stream.WriteArrayStart()
-
-		for i, ann := range rule.Annotations {
-			if i > 0 {
-				stream.WriteMore()
-			}
-
-			stream.WriteVal(ann)
-		}
-
-		stream.WriteArrayEnd()
+		util.WriteValsArray(stream, rule.Annotations)
 
 		hasWritten = true
 	}

--- a/internal/encoding/testdata/policy.rego
+++ b/internal/encoding/testdata/policy.rego
@@ -1,0 +1,364 @@
+package testdata
+
+import data.regal.util
+
+_find_nested_vars(obj) := [value |
+	walk(obj, [_, value])
+	value.type == "var"
+	indexof(value.value, "$") == -1
+]
+
+# simple assignment, i.e. `x := 100` returns `x`
+# always returns a single var, but wrapped in an
+# array for consistency
+_find_assign_vars(value) := var if {
+	value[1].type == "var"
+	var := [value[1]]
+}
+
+# 'destructuring' array assignment, i.e.
+# [a, b, c] := [1, 2, 3]
+# or
+# {a: b} := {"foo": "bar"}
+_find_assign_vars(value) := vars if {
+	value[1].type in {"array", "object"}
+	vars := _find_nested_vars(value[1])
+}
+
+# var declared via `some`, i.e. `some x` or `some x, y`
+_find_some_decl_vars(value) := [v |
+	some v in value
+	v.type == "var"
+]
+
+# single var declared via `some in`, i.e. `some x in y`
+_find_some_in_decl_vars(value) := vars if {
+	arr := value[0].value
+	count(arr) == 3
+
+	vars := _find_nested_vars(arr[1])
+}
+
+# two vars declared via `some in`, i.e. `some x, y in z`
+_find_some_in_decl_vars(value) := vars if {
+	arr := value[0].value
+	count(arr) == 4
+
+	vars := [v |
+		some i in [1, 2]
+		some v in _find_nested_vars(arr[i])
+	]
+}
+
+# METADATA
+# description: |
+#   find vars like input[x].foo[y] where x and y are vars
+#   note: value.type == "ref" check must have been done before calling this function
+find_ref_vars(value) := [var |
+	some i, var in value.value
+
+	i > 0
+	var.type == "var"
+]
+
+# one or two vars declared via `every`, i.e. `every x in y {}`
+# or `every`, i.e. `every x, y in y {}`
+_find_every_vars(value) := vars if {
+	key_var := [value.key |
+		value.key.type == "var"
+		indexof(value.key.value, "$") == -1
+	]
+	val_var := [value.value |
+		value.value.type == "var"
+		indexof(value.value.value, "$") == -1
+	]
+
+	vars := array.concat(key_var, val_var)
+}
+
+# METADATA
+# description: |
+#   traverses all nodes in provided terms (using `walk`), and returns an array with
+#   all variables declared in terms, i,e [x, y] or {x: y}, etc.
+find_term_vars(terms) := [term |
+	walk(terms, [_, term])
+
+	term.type == "var"
+]
+
+# METADATA
+# description: |
+#   traverses all nodes in provided terms (using `walk`), and returns true if any variable
+#   is found in terms, with early exit (as opposed to find_term_vars)
+has_term_var(terms) if {
+	walk(terms, [_, term])
+
+	term.type == "var"
+}
+
+_find_vars(value, last) := {"term": find_term_vars(function_ret_args(fn_name, value))} if {
+	last == "terms"
+	value[0].type == "ref"
+	value[0].value[0].type == "var"
+	value[0].value[0].value != "assign"
+
+	fn_name := ref_to_string(value[0].value)
+
+	not contains(fn_name, "$")
+	fn_name in all_function_names # regal ignore:external-reference
+	function_ret_in_args(fn_name, value)
+}
+
+# `=` isn't necessarily assignment, and only considering the variable on the
+# left-hand side is equally dubious, but we'll treat `x = 1` as `x := 1` for
+# the purpose of this function until we have a more robust way of dealing with
+# unification
+_find_vars(value, last) := {"assign": _find_assign_vars(value)} if {
+	last == "terms"
+	value[0].type == "ref"
+	value[0].value[0].type == "var"
+	value[0].value[0].value in {"assign", "eq"}
+}
+
+_find_vars(value, last) := {"somein": _find_some_in_decl_vars(value)} if {
+	last == "symbols"
+	value[0].type == "call"
+}
+
+_find_vars(value, last) := {"some": _find_some_decl_vars(value)} if {
+	last == "symbols"
+	value[0].type != "call"
+}
+
+_find_vars(value, last) := {"every": _find_every_vars(value)} if {
+	last == "terms"
+	value.domain
+}
+
+_find_vars(value, last) := {"args": arg_vars} if {
+	last == "args"
+
+	arg_vars := [arg |
+		some arg in value
+		arg.type == "var"
+	]
+
+	count(arg_vars) > 0
+}
+
+_rule_index(rule) := sprintf("%d", [i]) if {
+	some i, r in _rules # regal ignore:external-reference
+	r == rule
+}
+
+# METADATA
+# description: |
+#   traverses all nodes under provided node (using `walk`), and returns an array with
+#   all variables declared via assignment (:=), `some`, `every` and in comprehensions
+#   DEPRECATED: uses ast.found.vars instead
+find_vars(node) := array.concat(
+	[var |
+		walk(node, [path, value])
+
+		last := regal.last(path)
+		last in {"terms", "symbols", "args"}
+
+		var := _find_vars(value, last)[_][_]
+	],
+	[var |
+		walk(node, [_, value])
+
+		value.type == "ref"
+
+		some x, var in value.value
+		x > 0
+		var.type == "var"
+	],
+)
+
+# hack to work around the different input models of linting vs. the lsp package.. we
+# should probably consider something more robust
+_rules := input.rules
+
+_rules := data.workspace.parsed[input.regal.file.uri].rules if not input.rules
+
+# METADATA:
+# description: |
+#   object containing all variables found in the input AST, keyed first by the index of
+#   the rule where the variables were found (as a numeric string), and then the context
+#   of the variable, which will be one of:
+#   - term
+#   - assign
+#   - every
+#   - some
+#   - somein
+#   - ref
+found.vars[rule_index][context] contains var if {
+	some i, rule in _rules
+
+	# converting to string until https://github.com/open-policy-agent/opa/issues/6736 is fixed
+	rule_index := sprintf("%d", [i])
+
+	walk(rule, [path, value])
+
+	last := regal.last(path)
+	last in {"terms", "symbols", "args"}
+
+	some context, vars in _find_vars(value, last)
+	some var in vars
+}
+
+found.vars[rule_index].ref contains var if {
+	some i, rule in _rules
+
+	# converting to string until https://github.com/open-policy-agent/opa/issues/6736 is fixed
+	rule_index := sprintf("%d", [i])
+
+	walk(rule, [_, value])
+
+	value.type == "ref"
+
+	some x, var in value.value
+	x > 0
+	var.type == "var"
+}
+
+# METADATA
+# description: all refs found in module
+# scope: document
+found.refs[rule_index] contains value if {
+	some i, rule in _rules
+
+	# converting to string until https://github.com/open-policy-agent/opa/issues/6736 is fixed
+	rule_index := sprintf("%d", [i])
+
+	walk(rule, [_, value])
+
+	value.type == "ref"
+}
+
+found.refs[rule_index] contains value if {
+	some i, rule in _rules
+
+	# converting to string until https://github.com/open-policy-agent/opa/issues/6736 is fixed
+	rule_index := sprintf("%d", [i])
+
+	walk(rule, [_, value])
+
+	value[0].type == "ref"
+}
+
+# METADATA
+# description: all symbols found in module
+found.symbols[rule_index] contains value.symbols if {
+	some i, rule in _rules
+
+	# converting to string until https://github.com/open-policy-agent/opa/issues/6736 is fixed
+	rule_index := sprintf("%d", [i])
+
+	walk(rule, [_, value])
+}
+
+# METADATA
+# description: all comprehensions found in module
+found.comprehensions[rule_index] contains value if {
+	some i, rule in _rules
+
+	# converting to string until https://github.com/open-policy-agent/opa/issues/6736 is fixed
+	rule_index := sprintf("%d", [i])
+
+	walk(rule, [_, value])
+
+	value.type in {"arraycomprehension", "objectcomprehension", "setcomprehension"}
+}
+
+# METADATA
+# description: |
+#   finds all vars declared in `rule` *before* the `location` provided
+#   note: this isn't 100% accurate, as it doesn't take into account `=`
+#   assignments / unification, but it's likely good enough since other rules
+#   recommend against those
+find_vars_in_local_scope(rule, location) := [var |
+	var := found.vars[_rule_index(rule)][_][_] # regal ignore:external-reference
+
+	not is_wildcard(var)
+	_before_location(rule, var, util.to_location_object(location))
+]
+
+_end_location(location) := end if {
+	loc := util.to_location_object(location)
+	lines := split(loc.text, "\n")
+	end := {
+		"row": (loc.row + count(lines)) - 1,
+		"col": loc.col + count(regal.last(lines)),
+	}
+}
+
+# special case — the value location of the rule head "sees"
+# all local variables declared in the rule body
+_before_location(rule, _, location) if {
+	loc := util.to_location_object(location)
+
+	value_start := util.to_location_object(rule.head.value.location)
+
+	loc.row >= value_start.row
+	loc.col >= value_start.col
+
+	value_end := _end_location(util.to_location_object(rule.head.value.location))
+
+	loc.row <= value_end.row
+	loc.col <= value_end.col
+}
+
+_before_location(_, var, location) if {
+	util.to_location_object(var.location).row < util.to_location_object(location).row
+}
+
+_before_location(_, var, location) if {
+	var_loc := util.to_location_object(var.location)
+	loc := util.to_location_object(location)
+
+	var_loc.row == loc.row
+	var_loc.col < loc.col
+}
+
+# METADATA
+# description: find *only* names in the local scope, and not e.g. rule names
+find_names_in_local_scope(rule, location) := names if {
+	fn_arg_names := _function_arg_names(rule)
+	var_names := {var.value | some var in find_vars_in_local_scope(rule, util.to_location_object(location))}
+
+	names := fn_arg_names | var_names
+}
+
+_function_arg_names(rule) := {arg.value |
+	some arg in rule.head.args
+	arg.type == "var"
+}
+
+# METADATA
+# description: |
+#   similar to `find_vars_in_local_scope`, but returns all variable names in scope
+#   of the given location *and* the rule names present in the scope (i.e. module)
+find_names_in_scope(rule, location) := names if {
+	locals := find_names_in_local_scope(rule, util.to_location_object(location))
+
+	# parens below added by opa-fmt :)
+	names := (rule_names | imported_identifiers) | locals
+}
+
+# METADATA
+# description: |
+#   find all variables declared via `some` declarations (and *not* `some .. in`)
+#   in the scope of the given location
+find_some_decl_names_in_scope(rule, location) := {some_var.value |
+	some some_var in found.vars[_rule_index(rule)]["some"] # regal ignore:external-reference
+	_before_location(rule, some_var, location)
+}
+
+# METADATA
+# description: all expressions in module
+exprs[rule_index][expr_index] := expr if {
+	some rule_index, rule in input.rules
+	some expr_index, expr in rule.body
+}

--- a/internal/encoding/util/util.go
+++ b/internal/encoding/util/util.go
@@ -1,0 +1,52 @@
+package util
+
+import (
+	jsoniter "github.com/json-iterator/go"
+)
+
+func WriteValsArray[T any](stream *jsoniter.Stream, vals []T) {
+	stream.WriteArrayStart()
+
+	for i, val := range vals {
+		if i > 0 {
+			stream.WriteMore()
+		}
+
+		stream.WriteVal(val)
+	}
+
+	stream.WriteArrayEnd()
+}
+
+func WriteStringsArray(stream *jsoniter.Stream, vals []string) {
+	stream.WriteArrayStart()
+
+	for i, val := range vals {
+		if i > 0 {
+			stream.WriteMore()
+		}
+
+		stream.WriteString(val)
+	}
+
+	stream.WriteArrayEnd()
+}
+
+func WriteObject[V any](stream *jsoniter.Stream, obj map[string]V) {
+	stream.WriteObjectStart()
+
+	i := 0
+
+	for key, value := range obj {
+		if i > 0 {
+			stream.WriteMore()
+		}
+
+		stream.WriteObjectField(key)
+		stream.WriteVal(value)
+
+		i++
+	}
+
+	stream.WriteObjectEnd()
+}

--- a/pkg/transform/transform.go
+++ b/pkg/transform/transform.go
@@ -3,8 +3,9 @@ package transform
 import (
 	"reflect"
 
-	"github.com/anderseknert/roast/internal/transforms"
 	jsoniter "github.com/json-iterator/go"
+
+	"github.com/anderseknert/roast/internal/transforms"
 
 	"github.com/open-policy-agent/opa/v1/ast"
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -40,3 +40,32 @@ func GrowPtrSlice[T any](s []*T, n int) []*T {
 
 	return s
 }
+
+// Filter returns a new slice containing only the elements of s that
+// satisfy the predicate f. This function runs each element of s through
+// f twice in order to allocate exactly what is needed. This is commonly
+// *much* more efficient than appending blindly, but do not use this if
+// the predicate function is expensive to compute.
+func Filter[T any](s []T, f func(T) bool) []T {
+	n := 0
+
+	for i := range s {
+		if f(s[i]) {
+			n++
+		}
+	}
+
+	if n == 0 {
+		return nil
+	}
+
+	r := make([]T, 0, n)
+
+	for i := range s {
+		if f(s[i]) {
+			r = append(r, s[i])
+		}
+	}
+
+	return r
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -41,3 +41,24 @@ func stringRepeatMake(s string, n int) []*ast.Term {
 
 	return sl
 }
+
+// Without pre-allocating, this is more than twice as slow and results in 5 allocs/op.
+// BenchmarkFilter/Filter-10    5919769    191.0 ns/op    224 B/op    1 allocs/op
+// ...
+func BenchmarkFilter(b *testing.B) {
+	strings := []string{
+		"foo", "bar", "baz", "qux", "quux", "corge", "grault", "garply", "waldo", "fred", "plugh", "xyzzy", "thud",
+		"x", "y", "z", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "the", "lazy", "dog", "jumped", "over",
+		"the", "quick", "brown", "fox",
+	}
+
+	pred := func(s string) bool {
+		return len(s) > 3
+	}
+
+	b.Run("Filter", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = Filter(strings, pred)
+		}
+	})
+}


### PR DESCRIPTION
Fixes #15

Also in this PR:
- Use generic helpers for writing arrays and objects, greatly reducing boilerplate code
- Add an efficient Filter function to the util package
- Add a few benchmarks
- Fix mistake in golangci-lint gci configuration